### PR TITLE
Work changes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -47,7 +47,12 @@ require'nvim-treesitter.configs'.setup {
   },
 }
 
-require('telescope').setup{  defaults = { file_ignore_patterns = { "node_modules", "vendor" }} }
+local telescope = require('telescope')
+telescope.setup{  defaults = { file_ignore_patterns = { "node_modules", "vendor" }} }
+-- Load live grep args extension
+telescope.load_extension("live_grep_args")
+vim.keymap.set('n', '<leader>fg', telescope.extensions.live_grep_args.live_grep_args, { noremap = true })
+
 
 -- DEBUGGING ---
 -- Run setup for Mason

--- a/init.lua
+++ b/init.lua
@@ -5,6 +5,20 @@ source ~/.vimrc
 ]])
 vim.opt.termguicolors = true
 
+-- Ensure nvm-managed Node.js is in PATH for ALE/linters
+local nvm_dir = os.getenv("NVM_DIR")
+if nvm_dir then
+  local default_node = nvm_dir .. "/versions/node"
+  local handle = io.popen("ls -1 " .. default_node .. " 2>/dev/null | sort -V | tail -1")
+  if handle then
+    local latest = handle:read("*l")
+    handle:close()
+    if latest then
+      vim.env.PATH = default_node .. "/" .. latest .. "/bin:" .. vim.env.PATH
+    end
+  end
+end
+
 -- Run setup for Hop
 require'hop'.setup()
 

--- a/init.lua
+++ b/init.lua
@@ -134,6 +134,17 @@ end
 -- Set colorscheme
 vim.cmd.colorscheme(colorSchemeName)
 
+-- ALE linting status indicator
+vim.g.ale_linting = false
+vim.api.nvim_create_autocmd("User", {
+  pattern = "ALELintPre",
+  callback = function() vim.g.ale_linting = true; vim.cmd("redrawstatus") end,
+})
+vim.api.nvim_create_autocmd("User", {
+  pattern = "ALELintPost",
+  callback = function() vim.g.ale_linting = false; vim.cmd("redrawstatus") end,
+})
+
 -- Statusline
 local function git_branch()
     local branch = vim.fn.system("git rev-parse --abbrev-ref HEAD 2>/dev/null | tr -d '\n'")
@@ -151,6 +162,7 @@ local function statusline()
     local file_name = " %f"
     local modified = "%m"
     local align_right = "%="
+    local lint_status = vim.g.ale_linting and " [linting...] " or ""
     local fileencoding = " %{&fileencoding?&fileencoding:&encoding}"
     local fileformat = " [%{&fileformat}]"
     local filetype = " %y"
@@ -158,13 +170,14 @@ local function statusline()
     local linecol = " %l:%c"
 
     return string.format(
-        "%s %s %s%s%s%s%s%s%s%s%s",
+        "%s %s %s%s%s%s%s%s%s%s%s%s",
         set_color_1,
         branch,
         set_color_2,
         file_name,
         modified,
         align_right,
+        lint_status,
         filetype,
         fileencoding,
         fileformat,

--- a/init.lua
+++ b/init.lua
@@ -60,6 +60,29 @@ require("mason").setup()
 -- Setup Dap
 require('dap.setup').setup()
 
+--- Neotest
+require("neotest").setup({
+  adapters = {
+    require('neotest-jest')({
+      jestCommand = "npm test --",
+      jestConfigFile = "jest.config.ts",
+      env = { CI = true },
+      cwd = function(path)
+        return vim.fn.getcwd()
+      end,
+    }),
+  },
+})
+
+-- Run nearest test
+vim.api.nvim_set_keymap('n', 'mr', '<cmd>lua require("neotest").run.run()<CR><cmd>lua require("neotest").summary.open()<CR>', { noremap = true, silent = true })
+-- Open output
+vim.api.nvim_set_keymap('n', 'mo', '<cmd>lua require("neotest").output.open({ enter = true })<CR>', { noremap = true, silent = true })
+-- Run all tests in file
+vim.api.nvim_set_keymap('n', 'ma', '<cmd>lua require("neotest").run.run(vim.fn.expand("%"))<CR><cmd>lua require("neotest").summary.open()<CR>', { noremap = true, silent = true })
+-- Toggle summary
+vim.api.nvim_set_keymap('n', 'ms', '<cmd>lua require("neotest").summary.toggle()<CR>', { noremap = true, silent = true })
+
 -- Get iterm profile
 local iterm_profile = os.getenv('ITERM_PROFILE')
 if(iterm_profile == 'tokyonight-storm')

--- a/init.lua
+++ b/init.lua
@@ -90,7 +90,31 @@ then
   colorSchemeName = 'tokyonight-storm'
 else
   vim.o.background = 'light'
-  colorSchemeName = 'solarized8_high'
+  colorSchemeName = 'kanagawa'
+  require('kanagawa').setup({
+    compile = false,             -- enable compiling the colorscheme
+    undercurl = true,            -- enable undercurls
+    commentStyle = { italic = true },
+    functionStyle = {},
+    keywordStyle = { italic = true},
+    statementStyle = { bold = true },
+    typeStyle = {},
+    transparent = false,         -- do not set background color
+    dimInactive = false,         -- dim inactive window `:h hl-NormalNC`
+    terminalColors = true,       -- define vim.g.terminal_color_{0,17}
+    colors = {                   -- add/modify theme and palette colors
+        palette = {},
+        theme = { wave = {}, lotus = {}, dragon = {}, all = {} },
+    },
+    overrides = function(colors) -- add/modify highlights
+        return {}
+    end,
+    theme = "wave",              -- Load "wave" theme when 'background' option is not set
+    background = {               -- map the value of 'background' option to a theme
+        dark = "wave",           -- try "dragon" !
+        light = "lotus"
+    }, 
+  })
 end
 
 -- Set colorscheme

--- a/vimrc
+++ b/vimrc
@@ -157,6 +157,7 @@ Plug 'nvim-treesitter/nvim-treesitter', {'do': ':TSUpdate'}
 Plug 'nvim-lua/plenary.nvim'
 " Fuzzy finder
 Plug 'nvim-telescope/telescope.nvim'
+Plug 'nvim-telescope/telescope-live-grep-args.nvim'
 " Nvim tree with icons
 Plug 'kyazdani42/nvim-web-devicons' " for file icons
 Plug 'kyazdani42/nvim-tree.lua'
@@ -213,9 +214,10 @@ nnoremap N Nzz
 
 " Find files using Telescope command-line sugar.
 nnoremap <leader>ff <cmd>Telescope find_files<cr>
-nnoremap <leader>fg <cmd>Telescope live_grep<cr>
+" nnoremap <leader>fg <cmd>Telescope live_grep<cr>
 nnoremap <leader>fb <cmd>Telescope buffers<cr>
 nnoremap <leader>fh <cmd>Telescope help_tags<cr>
+nnoremap <leader>fr <cmd>Telescope resume<cr>
 
 " Nvim tree mappings
 nnoremap <leader>tt :NvimTreeToggle<CR>

--- a/vimrc
+++ b/vimrc
@@ -132,11 +132,17 @@ let g:NERDDefaultAlign = 'left'
 " PLUGINS ---------------------------------------------------------------- {{{
 " ALE linting settings
 let g:ale_linters = {
-\  'json': ['jq']
+\  'json': ['jq'],
+\  'javascript': ['eslint', 'tsserver'],
+\  'javascriptreact': ['eslint', 'tsserver'],
+\  'typescript': ['eslint', 'tsserver'],
+\  'typescriptreact': ['eslint', 'tsserver'],
 \}
 let g:ale_json_jq_executable = 'jq'
 let g:ale_json_jq_options = '.'
-let g:ale_fixers = ['prettier', 'eslint']
+let g:ale_fixers = {
+\  '*': ['prettier', 'eslint'],
+\}
 " Auto fix on save
 let g:ale_fix_on_save = 1
 

--- a/vimrc
+++ b/vimrc
@@ -189,6 +189,9 @@ Plug 'github/copilot.vim'
 " Color
 Plug 'folke/tokyonight.nvim'
 Plug 'rebelot/kanagawa.nvim'
+" Neotest
+" Plug 'nvim-lua/plenary.nvim'
+" Plug 'nvim-treesitter/nvim-treesitter'
 Plug 'antoinemadec/FixCursorHold.nvim'
 Plug 'nvim-neotest/nvim-nio'
 Plug 'nvim-neotest/neotest'

--- a/vimrc
+++ b/vimrc
@@ -195,7 +195,7 @@ call plug#end()
 
 
 " MAPPINGS --------------------------------------------------------------- {{{
-" Set the backslash as the leader key.
+" Set comma as the leader key.
 let mapleader = ","
 
 " Split mapping

--- a/vimrc
+++ b/vimrc
@@ -182,6 +182,7 @@ Plug 'preservim/nerdcommenter'
 Plug 'github/copilot.vim'
 " Color
 Plug 'folke/tokyonight.nvim'
+Plug 'rebelot/kanagawa.nvim'
 Plug 'antoinemadec/FixCursorHold.nvim'
 Plug 'nvim-neotest/nvim-nio'
 Plug 'nvim-neotest/neotest'

--- a/vimrc
+++ b/vimrc
@@ -182,6 +182,11 @@ Plug 'preservim/nerdcommenter'
 Plug 'github/copilot.vim'
 " Color
 Plug 'folke/tokyonight.nvim'
+Plug 'antoinemadec/FixCursorHold.nvim'
+Plug 'nvim-neotest/nvim-nio'
+Plug 'nvim-neotest/neotest'
+" Neotest-jest
+Plug 'nvim-neotest/neotest-jest'
 
 call plug#end()
 


### PR DESCRIPTION
**JavaScript/TypeScript Development Enhancements:**

* Expanded ALE linters and fixers to include `eslint` and `tsserver` for JavaScript, TypeScript, and their React variants, and switched to per-filetype fixer configuration for better control.
* Automatically prepends the latest nvm-managed Node.js version to the `PATH` in Neovim to ensure ALE and related tools use the correct Node.js binary.

**Testing Integration:**

* Added Neotest and Neotest-Jest plugins, with configuration and convenient keymaps.

**Search and Navigation Improvements:**

* Added the `telescope-live-grep-args` plugin and mapped `<leader>fg`. Also added a keymap for resuming previous Telescope searches.

**User Interface and Visuals:**

* Switched the default light colorscheme to Kanagawa with custom configuration, and added the plugin to the list.
* Enhanced the statusline to display ALE linting status in real time, with autocommands to update the indicator.